### PR TITLE
Submodule-checker, diagram checker and visual cleanup

### DIFF
--- a/.context.md
+++ b/.context.md
@@ -2,7 +2,10 @@
 module-name: Codebase Context Specification
 version: 1.0.0
 description: A specification for providing explicit context information about a codebase
-related-modules: []
+related-modules: 
+  - TypeScript Linter: ./linters/typescript
+  - Codebase Context Editor: ./examples/context-editor
+  - Three: ./invalid
 technologies:
   - Markdown
   - YAML
@@ -16,7 +19,7 @@ directives:
   - Maintain backward compatibility
   - Keep documentation up-to-date
 diagrams:
-  - context-hierarchy.png
+  - Dagram : ./img/codebase-diagram.mermaid
 architecture:
   style: Documentation-driven
   components:

--- a/.context.md
+++ b/.context.md
@@ -5,7 +5,6 @@ description: A specification for providing explicit context information about a 
 related-modules: 
   - TypeScript Linter: ./linters/typescript
   - Codebase Context Editor: ./examples/context-editor
-  - Three: ./invalid
 technologies:
   - Markdown
   - YAML

--- a/linters/.context.md
+++ b/linters/.context.md
@@ -1,7 +1,8 @@
 ---
 module-name: Codebase Context Specification Linters
 related-modules:
-  - ../examples
+  - TypeScript Linter: ./typescript
+  - Python Linter: ./python
 version: 1.0.0
 description: Contains linting tools for validating Codebase Context Specification files
 diagrams: []

--- a/linters/typescript/.context.md
+++ b/linters/typescript/.context.md
@@ -1,7 +1,7 @@
 ---
 module-name: TypeScript Linter for Codebase Context Specification
 related-modules:
-  - ../python
+  - Python Linter: ../python
 version: 1.0.0
 description: TypeScript implementation of the Codebase Context Specification linter
 diagrams: []

--- a/linters/typescript/src/utils/context_structure.ts
+++ b/linters/typescript/src/utils/context_structure.ts
@@ -53,5 +53,6 @@ export const stringTypes: Set<string> = new Set([
 ]);
 
 export const directoryTypes: Set<string> = new Set([
-  'related-modules'
+  'related-modules',
+  'diagrams'
 ]);


### PR DESCRIPTION
# Remove duplicate "Linting directory" output in context linter

## Description

This PR addresses an issue where the context linter was displaying a duplicate "Linting directory" line at the beginning of its output. The change removes the redundant console.log statement from the `lintDirectory` method in the `ContextLinter` class, relying solely on the `printHeader` function to display the initial linting information.

It also fixex recursion of files and adds stong validation to the directories, filespecs, and URLs in those areads.

## Changes made

- Removed a duplicate console.log statement from the `lintDirectory` method in `context_linter.ts`.
- The `printHeader` function now solely handles displaying the initial linting information, including the directory being linted.

This change results in a cleaner, non-redundant output when running the linter, improving the user experience and readability of the linter's output.

## Diff

```diff
--- a/linters/typescript/src/context_linter.ts
+++ b/linters/typescript/src/context_linter.ts
@@ -35,7 +35,6 @@ export class ContextLinter {
   public async lintDirectory(directoryPath: string, packageVersion: string): Promise<boolean> {
     try {
       printHeader(packageVersion, directoryPath);
-      console.log(`Linting directory: ${this.normalizePath(directoryPath)}\n`);
       let isValid = true;
       
       // Initialize ignore patterns
```

